### PR TITLE
Refactor Miner for additional pairs

### DIFF
--- a/database/database/schema/mined_project_schema.py
+++ b/database/database/schema/mined_project_schema.py
@@ -3,6 +3,7 @@ from .common_schema import NonEmptyStr
 MinedProjectSchema = {
     'repo': NonEmptyStr,
     'latest_mined_version': NonEmptyStr,
+    'last_date_mined': NonEmptyStr,
     'progression_metrics': {
         'type': 'dict',
         'allow_unknown': True,

--- a/database/database/schema/mined_project_schema.py
+++ b/database/database/schema/mined_project_schema.py
@@ -1,9 +1,9 @@
-from .common_schema import NonEmptyStr
+from .common_schema import NonEmptyStr, RequiredInt
 
 MinedProjectSchema = {
     'repo': NonEmptyStr,
     'latest_mined_version': NonEmptyStr,
-    'last_date_mined': NonEmptyStr,
+    'last_date_mined': RequiredInt,
     'progression_metrics': {
         'type': 'dict',
         'allow_unknown': True,

--- a/pair-filter/pair-filter.py
+++ b/pair-filter/pair-filter.py
@@ -68,7 +68,6 @@ class PairFilter(object):
         file_name = utils.canonical_repo(repo)
         file_path = os.path.join(os.path.dirname(os.path.realpath('.')),
                                  'pair-finder/output/original_metrics/{}.json'.format(file_name))
-        print(file_path)
         original_d = read_json(file_path)
 
         def _key(filter_name: str, pr: bool):

--- a/pair-filter/pair_filter/utils.py
+++ b/pair-filter/pair_filter/utils.py
@@ -103,6 +103,10 @@ def log_filter_count(filtered_count: int, reason: str):
     log.info('Filtered {:>4} {}.'.format(filtered_count, reason))
 
 
+def canonical_repo(repo: str) -> str:
+    return repo.replace('/', '-')
+
+
 def _registry_tags_list(repo_name):
     list_of_tags = []
     _, basic_auth, _, _ = _basic_auth()

--- a/pair-finder/pair_finder.py
+++ b/pair-finder/pair_finder.py
@@ -150,9 +150,8 @@ def _thread_main(repo, task_name, log_level, skip_if_output_exists, keep_clone):
     if not result:
         # A filter in the pipeline encountered a fatal error and made the pipeline exit early.
         # Skip writing the output file.
-        if os.path.exists(output_file_path):
-            os.remove(output_file_path)
-        return
+        log.info('Exiting the program as there are no jobs to continue mining.')
+        sys.exit(1)
 
     builder = out_context['mined_project_builder']
     builder.repo = repo

--- a/pair-finder/pair_finder.py
+++ b/pair-finder/pair_finder.py
@@ -10,6 +10,7 @@ from concurrent.futures import as_completed
 from concurrent.futures import ThreadPoolExecutor
 
 from bugswarm.common import log
+from bugswarm.common.json import write_json
 from bugswarm.common.utils import get_current_component_version_message
 
 from pair_finder.model.mined_project_builder import MinedProjectBuilder
@@ -171,6 +172,8 @@ def _thread_main(repo, task_name, log_level, skip_if_output_exists, keep_clone):
     mined_project = builder.build()
     OutputManager.output_to_database(mined_project)
     OutputManager.output(repo, output_path=output_file_path, branches=result)
+    metrics_output_file_path = Utils.output_metrics_path_from_repo(repo, task_name)
+    write_json(metrics_output_file_path, in_context['original_mined_project_metrics'])
 
     elapsed = time.time() - start_time
     log.info('Processed {} in {} seconds. Done!'.format(repo, elapsed))

--- a/pair-finder/pair_finder/model/mined_project_builder.py
+++ b/pair-finder/pair_finder/model/mined_project_builder.py
@@ -52,7 +52,7 @@ class MinedProjectBuilder(object):
             return {
                 'repo': '',
                 'latest_mined_version': '',
-                'last_date_mined': 'Mon, 01 Jan 1970 00:00:00 GMT',
+                'last_date_mined': 0,
                 'progression_metrics': {
                     'builds': 0,
                     'jobs': 0,

--- a/pair-finder/pair_finder/model/mined_project_builder.py
+++ b/pair-finder/pair_finder/model/mined_project_builder.py
@@ -63,4 +63,3 @@ class MinedProjectBuilder(object):
                 },
             }
         return results.json()
-

--- a/pair-finder/pair_finder/model/mined_project_builder.py
+++ b/pair-finder/pair_finder/model/mined_project_builder.py
@@ -43,7 +43,7 @@ class MinedProjectBuilder(object):
         }
 
     @staticmethod
-    def query_current_metrics(repo):
+    def query_current_metrics(repo: str) -> dict:
         log.info('Attempting to query metrics from database for {}'.format(repo))
         bugswarmapi = DatabaseAPI(token=DATABASE_PIPELINE_TOKEN)
         results = bugswarmapi.find_mined_project(repo)

--- a/pair-finder/pair_finder/model/mined_project_builder.py
+++ b/pair-finder/pair_finder/model/mined_project_builder.py
@@ -1,6 +1,3 @@
-import json
-import isodate
-
 from typing import Dict
 from datetime import datetime
 from bugswarm.common import log

--- a/pair-finder/pair_finder/model/mined_project_builder.py
+++ b/pair-finder/pair_finder/model/mined_project_builder.py
@@ -1,5 +1,5 @@
 from typing import Dict
-from datetime import datetime
+
 from bugswarm.common import log
 from bugswarm.common.credentials import DATABASE_PIPELINE_TOKEN
 from bugswarm.common.rest_api.database_api import DatabaseAPI

--- a/pair-finder/pair_finder/model/mined_project_builder.py
+++ b/pair-finder/pair_finder/model/mined_project_builder.py
@@ -1,4 +1,8 @@
+import json
+import isodate
+
 from typing import Dict
+from datetime import datetime
 from bugswarm.common import log
 from bugswarm.common.credentials import DATABASE_PIPELINE_TOKEN
 from bugswarm.common.rest_api.database_api import DatabaseAPI
@@ -20,11 +24,13 @@ class MinedProjectBuilder(object):
         self.mined_job_pairs = None
         self.mined_pr_build_pairs = None
         self.mined_pr_job_pairs = None
+        self.last_date_mined = self.set_current_date()
 
     def build(self) -> Dict:
         return {
             'repo': self.repo,
             'latest_mined_version': self.latest_mined_version,
+            'last_date_mined': self.last_date_mined,
             'progression_metrics': {
                 'builds': self.builds,
                 'jobs': self.jobs,
@@ -49,6 +55,7 @@ class MinedProjectBuilder(object):
             return {
                 'repo': '',
                 'latest_mined_version': '',
+                'last_date_mined': 'Mon, 01 Jan 1970 00:00:00 GMT',
                 'progression_metrics': {
                     'builds': 0,
                     'jobs': 0,
@@ -63,3 +70,8 @@ class MinedProjectBuilder(object):
                 },
             }
         return results.json()
+
+    def set_current_date(self):
+        today = datetime.today()
+        formatted_date = today.strftime('%a, %d %b %Y %H:%M:%S GMT')
+        return formatted_date

--- a/pair-finder/pair_finder/model/mined_project_builder.py
+++ b/pair-finder/pair_finder/model/mined_project_builder.py
@@ -1,4 +1,7 @@
 from typing import Dict
+from bugswarm.common import log
+from bugswarm.common.credentials import DATABASE_PIPELINE_TOKEN
+from bugswarm.common.rest_api.database_api import DatabaseAPI
 
 
 class MinedProjectBuilder(object):
@@ -35,3 +38,29 @@ class MinedProjectBuilder(object):
                 'mined_pr_job_pairs': self.mined_pr_job_pairs,
             },
         }
+
+    @staticmethod
+    def query_current_metrics(repo):
+        log.info('Attempting to query metrics from database for {}'.format(repo))
+        bugswarmapi = DatabaseAPI(token=DATABASE_PIPELINE_TOKEN)
+        results = bugswarmapi.find_mined_project(repo)
+        if results.status_code != 200:
+            log.info('Repository: {} has yet to be mined. Continuing.'.format(repo))
+            return {
+                'repo': '',
+                'latest_mined_version': '',
+                'progression_metrics': {
+                    'builds': 0,
+                    'jobs': 0,
+                    'failed_builds': 0,
+                    'failed_jobs': 0,
+                    'failed_pr_builds': 0,
+                    'failed_pr_jobs': 0,
+                    'mined_build_pairs': 0,
+                    'mined_job_pairs': 0,
+                    'mined_pr_build_pairs': 0,
+                    'mined_pr_job_pairs': 0,
+                },
+            }
+        return results.json()
+

--- a/pair-finder/pair_finder/model/mined_project_builder.py
+++ b/pair-finder/pair_finder/model/mined_project_builder.py
@@ -21,7 +21,7 @@ class MinedProjectBuilder(object):
         self.mined_job_pairs = None
         self.mined_pr_build_pairs = None
         self.mined_pr_job_pairs = None
-        self.last_date_mined = self.set_current_date()
+        self.last_date_mined = None
 
     def build(self) -> Dict:
         return {
@@ -67,8 +67,3 @@ class MinedProjectBuilder(object):
                 },
             }
         return results.json()
-
-    def set_current_date(self):
-        today = datetime.today()
-        formatted_date = today.strftime('%a, %d %b %Y %H:%M:%S GMT')
-        return formatted_date

--- a/pair-finder/pair_finder/pipeline/steps/get_jobs_from_travis_api.py
+++ b/pair-finder/pair_finder/pipeline/steps/get_jobs_from_travis_api.py
@@ -9,8 +9,8 @@ from typing import Any
 from typing import Optional
 from typing import Tuple
 from requests.exceptions import RequestException
-import dateutil.parser
 from datetime import datetime
+import dateutil.parser
 
 from bugswarm.common import log
 from bugswarm.common.json import read_json
@@ -77,18 +77,15 @@ class GetJobsFromTravisAPI(Step):
         for build in build_list:
             try:
                 # build['finished_at'] returns an ISO 8601 time representation. Ex - 2015-07-13T12:40:51Z
-                # while context['last_date_mined'] returns a String object formatted as: 'Tue, 28 Apr 2015 00:00:00 GMT'
-                # We must reformat the time ISO time representation to be formatted similarly as a String. Both strings
-                # are then converted to a datetime object for comparison.
+                # while context['last_date_mined'] returns an int representing Unix Epoch formatted as: '1580098839'
+                # We must convert the ISODate representation to datetime and the Unix Epoch to datetime for comparison
                 parsed_time = dateutil.parser.parse(build['finished_at'])
                 build_formatted_date = parsed_time.strftime('%a, %d %b %Y %H:%M:%S GMT')
                 build_date = datetime.strptime(build_formatted_date, '%a, %d %b %Y %H:%M:%S GMT')
-                last_mined_date = datetime.strptime(context['original_mined_project_metrics']['last_date_mined'],
-                                                    '%a, %d %b %Y %H:%M:%S GMT')
+                last_mined_date = datetime.fromtimestamp(context['original_mined_project_metrics']['last_date_mined'])
                 if latest_build_date_time < build_date:
                     latest_build_date_time = build_date
-                    context['mined_project_builder'].last_date_mined = \
-                        latest_build_date_time.strftime('%a, %d %b %Y %H:%M:%S GMT')
+                    context['mined_project_builder'].last_date_mined = latest_build_date_time.timestamp()
                 if build_date <= last_mined_date:
                     continue
             except KeyError:

--- a/pair-finder/pair_finder/pipeline/steps/get_jobs_from_travis_api.py
+++ b/pair-finder/pair_finder/pipeline/steps/get_jobs_from_travis_api.py
@@ -9,7 +9,7 @@ from typing import Any
 from typing import Optional
 from typing import Tuple
 from requests.exceptions import RequestException
-import dateutil.parser as dp
+import dateutil.parser
 
 from bugswarm.common import log
 from bugswarm.common.json import read_json
@@ -78,8 +78,8 @@ class GetJobsFromTravisAPI(Step):
                 # build['finished_at'] returns an ISO 8601 time representation. Ex - 2015-07-13T12:40:51Z
                 # while context['..']['_updated'] returns an ISODate object formatted as: Tue, 28 Apr 2015 00:00:00 GMT.
                 # We must reformat the time ISO time representation to be formatted similarly so we can compare.
-                t = dp.parse(build['finished_at'])
-                build_formatted_date = t.strftime('%a, %d %b %Y %H:%M:%S GMT')
+                parsed_time = dateutil.parser.parse(build['finished_at'])
+                build_formatted_date = parsed_time.strftime('%a, %d %b %Y %H:%M:%S GMT')
                 if build_formatted_date < context['original_mined_project_metrics']['_updated']:
                     continue
             except KeyError:

--- a/pair-finder/pair_finder/pipeline/steps/get_jobs_from_travis_api.py
+++ b/pair-finder/pair_finder/pipeline/steps/get_jobs_from_travis_api.py
@@ -8,14 +8,12 @@ import time
 from typing import Any
 from typing import Optional
 from typing import Tuple
+from requests.exceptions import RequestException
 
 from bugswarm.common import log
 from bugswarm.common.json import read_json
 from bugswarm.common.json import write_json
 from bugswarm.common.travis_wrapper import TravisWrapper
-from bugswarm.common.credentials import DATABASE_PIPELINE_TOKEN
-from bugswarm.common.rest_api.database_api import DatabaseAPI
-from requests.exceptions import RequestException
 
 from .step import Step
 from .step import StepException

--- a/pair-finder/pair_finder/pipeline/steps/get_jobs_from_travis_api.py
+++ b/pair-finder/pair_finder/pipeline/steps/get_jobs_from_travis_api.py
@@ -73,6 +73,7 @@ class GetJobsFromTravisAPI(Step):
         #   LEFT JOIN commits c on b.commit = c.sha
         #   WHERE j.repo_id = "<repo_id>"
         jobs = []
+        latest_build_date_time = datetime(1970, 1, 1)
         for build in build_list:
             try:
                 # build['finished_at'] returns an ISO 8601 time representation. Ex - 2015-07-13T12:40:51Z
@@ -84,7 +85,11 @@ class GetJobsFromTravisAPI(Step):
                 build_date = datetime.strptime(build_formatted_date, '%a, %d %b %Y %H:%M:%S GMT')
                 last_mined_date = datetime.strptime(context['original_mined_project_metrics']['last_date_mined'],
                                                     '%a, %d %b %Y %H:%M:%S GMT')
-                if build_date < last_mined_date:
+                if latest_build_date_time < build_date:
+                    latest_build_date_time = build_date
+                    context['mined_project_builder'].last_date_mined = \
+                        latest_build_date_time.strftime('%a, %d %b %Y %H:%M:%S GMT')
+                if build_date <= last_mined_date:
                     continue
             except KeyError:
                 pass

--- a/pair-finder/pair_finder/utils.py
+++ b/pair-finder/pair_finder/utils.py
@@ -22,6 +22,7 @@ CLONE_DIR = 'intermediates/clones'
 HISTORY_DIR = 'intermediates/histories'
 LOG_DIR = 'intermediates/logs'
 OUTPUT_DIR = 'output'
+ORIGNAL_METRICS_DIR = 'output/original_metrics'
 API_RESULT_DIR = 'intermediates/api-results'
 
 
@@ -38,6 +39,7 @@ class Utils(object):
         os.makedirs(LOG_DIR, exist_ok=True)
         os.makedirs(API_RESULT_DIR, exist_ok=True)
         os.makedirs(OUTPUT_DIR, exist_ok=True)
+        os.makedirs(ORIGNAL_METRICS_DIR, exist_ok=True)
         task_dir = os.path.join(OUTPUT_DIR, task_name)
         os.makedirs(task_dir, exist_ok=True)
 
@@ -188,6 +190,11 @@ class Utils(object):
         filename = Utils._canonical_repo(repo) + '.json'
         task_dir = os.path.join(OUTPUT_DIR, task_name)
         return os.path.join(task_dir, filename)
+
+    @staticmethod
+    def output_metrics_path_from_repo(repo: str, task_name: str) -> str:
+        filename = Utils._canonical_repo(repo) + '.json'
+        return os.path.join(ORIGNAL_METRICS_DIR, filename)
 
     @staticmethod
     def log_file_path_from_repo(repo: str) -> str:


### PR DESCRIPTION
The purpose of the refactoring was to address the problem of overwriting the data in the database. The original implementation does not add additional metrics, but rather upserted the data thus overwriting any previous value. This fix will add onto the original metrics if the project was previously mined.

- Refactored `pair-finder` to query the database once to see if the project has been mined previously. We will either return a blank template or it's original metrics to output to a json file to be used in `pair-filter`.
- `pair-finder` will now add on additional pairs and metrics within the pipeline
- `pair-finder` will exit the pipeline and not proceed if there are no jobs to reproduce
- Introduced a new DB attribute called `last_mined_date` which will hold the latest date since the project was last mined.