### PR TITLE
Sync master branches between bugswarm-dev and bugswarm

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -14,6 +14,9 @@
 #
 # The actual sync logic is implemented in this GitHub action:
 # https://github.com/BugSwarm/git-mirror-action
+#
+# The bot account's SSH private key needs to be stored as secrets in both private
+# and public repos in order for the `git-mirror-action` workflow to work.
 
 
 name: Sync

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,54 @@
+# == Rational ==
+# To enable development work in private repo, but at the same time open our work
+# in master branch to the public.
+#
+# == Description ==
+# Whenever a push event to master branch happens in this repo, this workflow syncs
+# master branches between the current repo and the corresponding public/private
+# repo, as defined in `env`.
+#
+# == Notes ==
+# Due to the limitation of expressions in GitHub Actions, we define two `steps`
+# with `if` conditions such that only one will be executed during a given `build`,
+# depending on whether the current repo is private or public.
+#
+# The actual sync logic is implemented in this GitHub action:
+# https://github.com/BugSwarm/git-mirror-action
+
+
+name: Sync
+
+on:
+  push:
+    branches:
+      - master
+
+env:
+  PRIVATE_REPO: 'BugSwarm/bugswarm-dev'
+  PUBLIC_REPO: 'BugSwarm/bugswarm'
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    # If the current repo is private, then push master branch to the public repo
+    - name: Sync to public repo
+      if: github.repository == env.PRIVATE_REPO
+      uses: BugSwarm/git-mirror-action@master
+      env:
+        SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+      with:
+        source-repo: 'git@github.com:${{ env.PRIVATE_REPO }}.git'
+        destination-repo: 'git@github.com:${{ env.PUBLIC_REPO }}.git'
+
+    # If the current repo is public, then push master branch to the private repo
+    - name: Sync to private repo
+      if: github.repository == env.PUBLIC_REPO
+      uses: BugSwarm/git-mirror-action@master
+      env:
+        SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+      with:
+        source-repo: 'git@github.com:${{ env.PUBLIC_REPO }}.git'
+        destination-repo: 'git@github.com:${{ env.PRIVATE_REPO }}.git'


### PR DESCRIPTION
This GitHub action enables syncing of master branches between private repo `bugswarm-dev` and public repo `bugswarm`. More details can be found in the header comments.

Here's the migration plan:

- [x] Create the private repo `bugswarm-dev`.
- [x] Store the SSH private key of the bot (@BugSwarmDummy) as a secret in `bugswarm-dev` repo.
- [x] Store the SSH private key of the bot (@BugSwarmDummy) as a secret in `bugswarm` repo.
- [ ] Merge this PR, so we sync this repo to `bugswarm-dev`.
- [ ] Have everyone update their git remote origin to `bugswarm-dev`'s git URL, so people push changes to the new private repo by default.

I'll need help from @dtomassi to store the secret in this repo as it requires admin privilege. For the last step, we need to run this command under `bugswarm` repo:

```
git remote set-url origin git@github.com:BugSwarm/bugswarm-dev.git
```

If it sounds like a plan, we can proceed the steps mentioned above. 