### PR TITLE
Install newer version of npm

### DIFF
--- a/provision.sh
+++ b/provision.sh
@@ -118,7 +118,7 @@ curl -fsSL https://deb.nodesource.com/setup_19.x | sudo -E bash - &&\
 sudo apt-get install -y nodejs
 exit_if_failed 'Installing npm failed.'
 print_green 'Install puppeteer'
-npm i puppeteer
+npm i puppeteer@19.4.0
 exit_if_failed 'Installing puppeteer failed.'
 print_green 'Install puppeteer dependencies'
 sudo apt update

--- a/provision.sh
+++ b/provision.sh
@@ -114,7 +114,10 @@ fi
 
 # Install puppeteer and its dependencies via npm, for web scraping functionality used by pair-classifier.
 print_green 'Install npm'
-sudo apt-get install -y npm
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.2/install.sh | bash
+export NVM_DIR="$([ -z "${XDG_CONFIG_HOME-}" ] && printf %s "${HOME}/.nvm" || printf %s "${XDG_CONFIG_HOME}/nvm")"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" # This loads nvm
+nvm install node
 exit_if_failed 'Installing npm failed.'
 print_green 'Install puppeteer'
 npm i puppeteer

--- a/provision.sh
+++ b/provision.sh
@@ -114,10 +114,8 @@ fi
 
 # Install puppeteer and its dependencies via npm, for web scraping functionality used by pair-classifier.
 print_green 'Install npm'
-curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.2/install.sh | bash
-export NVM_DIR="$([ -z "${XDG_CONFIG_HOME-}" ] && printf %s "${HOME}/.nvm" || printf %s "${XDG_CONFIG_HOME}/nvm")"
-[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" # This loads nvm
-nvm install node
+curl -fsSL https://deb.nodesource.com/setup_19.x | sudo -E bash - &&\
+sudo apt-get install -y nodejs
 exit_if_failed 'Installing npm failed.'
 print_green 'Install puppeteer'
 npm i puppeteer


### PR DESCRIPTION
When using `docker build -t bugswarm-spawner .` to build spawner, the `node` and `npm` installed by `apt-get` seems too old, which produces the following error when trying to install puppeteer:
``` text
#9 391.7 Install puppeteer
#9 398.2 
#9 398.2 > puppeteer@19.4.0 postinstall /home/bugswarm/bugswarm/node_modules/puppeteer
#9 398.2 > node install.js
#9 398.2 
#9 398.6 internal/modules/cjs/loader.js:638
#9 398.6     throw err;
#9 398.6     ^
#9 398.6 
#9 398.6 Error: Cannot find module 'puppeteer/internal/node/install.js'
#9 398.6     at Function.Module._resolveFilename (internal/modules/cjs/loader.js:636:15)
#9 398.6     at Function.Module._load (internal/modules/cjs/loader.js:562:25)
#9 398.6     at Module.require (internal/modules/cjs/loader.js:692:17)
#9 398.6     at require (internal/modules/cjs/helpers.js:25:18)
#9 398.6     at Object.<anonymous> (/home/bugswarm/bugswarm/node_modules/puppeteer/install.js:38:27)
#9 398.6     at Module._compile (internal/modules/cjs/loader.js:778:30)
#9 398.6     at Object.Module._extensions..js (internal/modules/cjs/loader.js:789:10)
#9 398.6     at Module.load (internal/modules/cjs/loader.js:653:32)
#9 398.6     at tryModuleLoad (internal/modules/cjs/loader.js:593:12)
#9 398.6     at Function.Module._load (internal/modules/cjs/loader.js:585:3)
#9 398.9 npm WARN notsup Unsupported engine for puppeteer@19.4.0: wanted: {"node":">=14.1.0"} (current: {"node":"10.19.0","npm":"6.14.4"})
#9 398.9 npm WARN notsup Not compatible with your version of node/npm: puppeteer@19.4.0
#9 398.9 npm WARN notsup Unsupported engine for cosmiconfig@8.0.0: wanted: {"node":">=14"} (current: {"node":"10.19.0","npm":"6.14.4"})
#9 398.9 npm WARN notsup Not compatible with your version of node/npm: cosmiconfig@8.0.0
#9 398.9 npm WARN notsup Unsupported engine for puppeteer-core@19.4.0: wanted: {"node":">=14.1.0"} (current: {"node":"10.19.0","npm":"6.14.4"})
#9 398.9 npm WARN notsup Not compatible with your version of node/npm: puppeteer-core@19.4.0
#9 398.9 npm WARN enoent ENOENT: no such file or directory, open '/home/bugswarm/bugswarm/package.json'
#9 398.9 npm WARN bugswarm No description
#9 398.9 npm WARN bugswarm No repository field.
#9 398.9 npm WARN bugswarm No README data
#9 398.9 npm WARN bugswarm No license field.
#9 398.9 
#9 399.0 npm ERR! code ELIFECYCLE
#9 399.0 npm ERR! errno 1
#9 399.0 npm ERR! puppeteer@19.4.0 postinstall: `node install.js`
#9 399.0 npm ERR! Exit status 1
#9 399.0 npm ERR! 
#9 399.0 npm ERR! Failed at the puppeteer@19.4.0 postinstall script.
#9 399.0 npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
#9 399.0 
#9 399.0 npm ERR! A complete log of this run can be found in:
#9 399.0 npm ERR!     /home/bugswarm/.npm/_logs/2022-12-16T04_12_27_965Z-debug.log
#9 399.1 
#9 399.1 ERROR: Installing puppeteer failed. Exiting.
```

Using `nvm` to install a newer version of `node` solves the problem.